### PR TITLE
Clarify when to use a named callback vs anonymous

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ We pass in a function as the lone argument, store it inside the `thing` variable
 ### Callback functions
 If you've done any outside reading on JavaScript, you've probably come across the name of the pattern we just introduced: _callback functions_. When we pass a function into another function wherein it might be invoked, we refer to the passed function as a _callback_. The term derives from the fact that the function isn't invoked immediately — instead it's _called back_, or invoked at a later point.
 
-You may have noticed, but all of our callback functions so far have been _anonymous functions_; that is, we haven't assigned them an identifier. You're welcome to name your callback functions if you'd like, but generally it just clutters things up. And, anyway, we already have a way to refer to them: by the name of the parameter into which they're passed! For example:
+You may have noticed, but all of our callback functions so far have been _anonymous functions_; that is, we haven't assigned them an identifier. You're welcome to name your callback functions if you'd like, but generally it just clutters things up if you only use the callback function in one place. And, anyway, we already have a way to refer to them: by the name of the parameter into which they're passed! For example:
 ```js
 function main (cb) {
   console.log(cb());


### PR DESCRIPTION
@gabe it is generally best practice and a code smell to have anonymous functions that use the keyword "function" (arrow functions are entirely different) as they hard to debug. I think a middle ground would be best here, as really naming a function would be the best option if you use the same function as a callback in multiple locations (something done often in React / Angular). Just my 2 cents, but I always teach student it is always better to name a function than be anonymous. As stated arrow functions are a whole different beast, and normally used just to maintain scope of `this`.